### PR TITLE
fix: make it compatible to 3.13, fix #3

### DIFF
--- a/Qiber3D/core.py
+++ b/Qiber3D/core.py
@@ -297,7 +297,7 @@ class Network:
 
         self.center = self.bbox[0] + (self.bbox[1] - self.bbox[0]) / 2.0
         self.bbox_size = self.bbox[1] - self.bbox[0]
-        self.bbox_volume = np.product(self.bbox_size)
+        self.bbox_volume = np.prod(self.bbox_size)
 
         self.vector = np.vstack([seg.vector for seg in self.segment.values()])
         self.direction = np.array([seg.direction for seg in self.segment.values()])

--- a/Qiber3D/reconstruct.py
+++ b/Qiber3D/reconstruct.py
@@ -11,8 +11,9 @@ import Qiber3D
 
 
 class Reconstruct:  # BJH
-
-    logger = Qiber3D.helper.get_logger()
+    def __init__(self):
+        import Qiber3D.helper
+        self.logger = Qiber3D.helper.get_logger()
 
     @staticmethod
     def __paths_to_edges(paths):

--- a/Qiber3D/reconstruct.py
+++ b/Qiber3D/reconstruct.py
@@ -8,12 +8,13 @@ from skimage.morphology import skeletonize
 from tqdm import tqdm
 
 import Qiber3D
-
+import Qiber3D.helper  # ensure helper is available at module import time
 
 class Reconstruct:  # BJH
+    logger = Qiber3D.helper.get_logger()
+
     def __init__(self):
-        import Qiber3D.helper
-        self.logger = Qiber3D.helper.get_logger()
+        self.logger = self.__class__.logger
 
     @staticmethod
     def __paths_to_edges(paths):


### PR DESCRIPTION
Before patching this

```
>>> import Qiber3D
Traceback (most recent call last):
  File "<python-input-11>", line 1, in <module>
    import Qiber3D
  File "/usr/lib/python3.13/site-packages/Qiber3D/__init__.py", line 16, in <module>
    from .reconstruct import Reconstruct
  File "/usr/lib/python3.13/site-packages/Qiber3D/reconstruct.py", line 13, in <module>
    class Reconstruct:  # BJH
    ...<378 lines>...
            return net
  File "/usr/lib/python3.13/site-packages/Qiber3D/reconstruct.py", line 15, in Reconstruct
    logger = Qiber3D.helper.get_logger()
             ^^^^^^^^^^^^^^
AttributeError: partially initialized module 'Qiber3D' from '/usr/lib/python3.13/site-packages/Qiber3D/__init__.py' has no attribute 'helper' (most likely due to a circular import)
```